### PR TITLE
Allow negative values for margins

### DIFF
--- a/apps/wl-paper/src/cli.rs
+++ b/apps/wl-paper/src/cli.rs
@@ -20,16 +20,16 @@ struct WlPaper {
     #[clap(long, value_enum, value_name = "SHELL")]
     generate_completion: Option<Shell>,
     /// The top margin.
-    #[clap(long, default_value = "0")]
+    #[clap(long, default_value = "0", allow_hyphen_values = true)]
     margin_top: i32,
     /// The right margin.
-    #[clap(long, default_value = "0")]
+    #[clap(long, default_value = "0", allow_hyphen_values = true)]
     margin_right: i32,
     /// The bottom margin.
-    #[clap(long, default_value = "0")]
+    #[clap(long, default_value = "0", allow_hyphen_values = true)]
     margin_bottom: i32,
     /// The left margin.
-    #[clap(long, default_value = "0")]
+    #[clap(long, default_value = "0", allow_hyphen_values = true)]
     margin_left: i32,
     /// The keyboard interactivity.
     #[clap(long, default_value = "on-demand")]


### PR DESCRIPTION
I noticed these margin arguments are `i32` typed, however clap will reject them as they start with `-` by default. For these, `allow_hyphen_values` should be added.

And.. so I also have a quick question here: I need the negative margin values because when the top bar (like waybar/DankMaterialShell bar) is present, `wl-paper --layer overlay` will not make the started program occupy the whole screen, but the space after the bar. The workaround is adding a negative margin-top value something like `-28`. Is there another fixed way to let `wl-paper` always occupy the whole screen no matter a top bar is present?

My wayland layers are:

```console
~ ❯ niri msg layers                                                                                                            12:14:23
Output "DP-2":
  Background layer:
    Surface:
      Namespace: "quickshell"
      Keyboard interactivity: none

  Bottom layer: (empty)

  Top layer:
    Surface:
      Namespace: "dms:bar"
      Keyboard interactivity: none

    Surface:
      Namespace: "dms:dock"
      Keyboard interactivity: none

  Overlay layer: (empty)

  ## `wl-paper --layer overlay xxx` will show here ##
```