### PR TITLE
Enforce single use of WAYLAND_SOCKET

### DIFF
--- a/apps/log-dmabuf-feedback/src/cli.rs
+++ b/apps/log-dmabuf-feedback/src/cli.rs
@@ -2,7 +2,7 @@ use {
     crate::{HfError, hf},
     clap::{CommandFactory, Parser, ValueHint},
     clap_complete::Shell,
-    std::io::stdout,
+    std::{io::stdout, os::fd::OwnedFd},
 };
 
 /// This application prints all dma-buf feedback sent to the application.
@@ -21,7 +21,7 @@ struct WlFormatFilter {
     program: Option<Vec<String>>,
 }
 
-pub fn main() -> Result<(), HfError> {
+pub fn main(wayland_socket: Option<OwnedFd>) -> Result<(), HfError> {
     let args = WlFormatFilter::parse();
     if let Some(shell) = args.generate_completion {
         let stdout = stdout();
@@ -34,5 +34,5 @@ pub fn main() -> Result<(), HfError> {
         );
         return Ok(());
     }
-    hf::main(args.program.unwrap())
+    hf::main(wayland_socket, args.program.unwrap())
 }

--- a/apps/log-dmabuf-feedback/src/hf.rs
+++ b/apps/log-dmabuf-feedback/src/hf.rs
@@ -29,11 +29,13 @@ use {
     },
 };
 
-pub fn main(program: Vec<String>) -> Result<(), HfError> {
-    let server = SimpleProxy::new(Baseline::ALL_OF_THEM).map_err(HfError::CreateServer)?;
+pub fn main(wayland_socket: Option<OwnedFd>, program: Vec<String>) -> Result<(), HfError> {
+    let server =
+        SimpleProxy::new(Baseline::ALL_OF_THEM, wayland_socket).map_err(HfError::CreateServer)?;
     Command::new(&program[0])
         .args(&program[1..])
-        .with_wayland_display(server.display())
+        .with_optional_wayland_display(server.display())
+        .with_optional_wayland_socket(server.socket())
         .spawn_and_forward_exit_code()
         .map_err(HfError::SpawnChild)?;
     let err = server.run(|| WlDisplayHandlerImpl);

--- a/apps/log-dmabuf-feedback/src/main.rs
+++ b/apps/log-dmabuf-feedback/src/main.rs
@@ -1,4 +1,12 @@
-use {error_reporter::Report, std::io, thiserror::Error, wl_proxy::simple::SimpleProxyError};
+use {
+    error_reporter::Report,
+    std::io,
+    thiserror::Error,
+    wl_proxy::{
+        simple::SimpleProxyError,
+        state::{StateError, get_wayland_socket},
+    },
+};
 
 mod cli;
 mod hf;
@@ -6,6 +14,8 @@ mod libdrm;
 
 #[derive(Debug, Error)]
 enum HfError {
+    #[error("could not extract WAYLAND_SOCKET")]
+    WaylandSocket(#[source] StateError),
     #[error("could not create a simple server")]
     CreateServer(#[source] SimpleProxyError),
     #[error("could not spawn child")]
@@ -15,5 +25,9 @@ enum HfError {
 }
 
 fn main() -> Result<(), Report<HfError>> {
-    cli::main().map_err(Report::new)
+    let wayland_socket = unsafe {
+        // SAFETY: only reader of WAYLAND_SOCKET, child processes all remove/replace it
+        get_wayland_socket().map_err(HfError::WaylandSocket)?
+    };
+    cli::main(wayland_socket).map_err(Report::new)
 }

--- a/apps/window-to-tray/src/cli.rs
+++ b/apps/window-to-tray/src/cli.rs
@@ -5,7 +5,7 @@ use {
     },
     clap::{CommandFactory, Parser, ValueHint},
     clap_complete::Shell,
-    std::{io::stdout, num::ParseIntError, sync::Arc},
+    std::{io::stdout, num::ParseIntError, os::fd::OwnedFd, sync::Arc},
     thiserror::Error,
 };
 
@@ -111,7 +111,7 @@ fn parse_color(s: &str) -> Result<Color, ParseColorError> {
     })
 }
 
-pub fn main() -> Result<(), WttError> {
+pub fn main(wayland_socket: Option<OwnedFd>) -> Result<(), WttError> {
     let args = WindowToTray::parse();
     if let Some(shell) = args.generate_completion {
         let stdout = stdout();
@@ -130,5 +130,5 @@ pub fn main() -> Result<(), WttError> {
         border_color: args.border_color,
         border_width: args.border_width,
     };
-    wtt::main(theme, &args.program.unwrap())
+    wtt::main(theme, wayland_socket, &args.program.unwrap())
 }

--- a/apps/window-to-tray/src/main.rs
+++ b/apps/window-to-tray/src/main.rs
@@ -6,12 +6,20 @@ mod icon;
 mod wtt;
 
 use {
-    error_reporter::Report, log::LevelFilter, std::io, thiserror::Error,
-    wl_proxy::simple::SimpleProxyError,
+    error_reporter::Report,
+    log::LevelFilter,
+    std::io,
+    thiserror::Error,
+    wl_proxy::{
+        simple::SimpleProxyError,
+        state::{StateError, get_wayland_socket},
+    },
 };
 
 #[derive(Debug, Error)]
 enum WttError {
+    #[error("could not extract WAYLAND_SOCKET")]
+    WaylandSocket(#[source] StateError),
     #[error("could not create a simple server")]
     CreateServer(#[source] SimpleProxyError),
     #[error("could not spawn child")]
@@ -21,9 +29,14 @@ enum WttError {
 }
 
 fn main() -> Result<(), Report<WttError>> {
+    let wayland_socket = unsafe {
+        // SAFETY: only reader of WAYLAND_SOCKET, child processes all remove/replace it
+        get_wayland_socket().map_err(WttError::WaylandSocket)?
+    };
+
     env_logger::builder()
         .filter_level(LevelFilter::Info)
         .parse_default_env()
         .init();
-    cli::main().map_err(Report::new)
+    cli::main(wayland_socket).map_err(Report::new)
 }

--- a/apps/window-to-tray/src/wtt.rs
+++ b/apps/window-to-tray/src/wtt.rs
@@ -117,11 +117,16 @@ use {
     },
 };
 
-pub fn main(theme: Theme, program: &[String]) -> Result<(), WttError> {
-    let server = SimpleProxy::new(Baseline::V5).map_err(WttError::CreateServer)?;
+pub fn main(
+    theme: Theme,
+    wayland_socket: Option<OwnedFd>,
+    program: &[String],
+) -> Result<(), WttError> {
+    let server = SimpleProxy::new(Baseline::V5, wayland_socket).map_err(WttError::CreateServer)?;
     Command::new(&program[0])
         .args(&program[1..])
-        .with_wayland_display(server.display())
+        .with_optional_wayland_display(server.display())
+        .with_optional_wayland_socket(server.socket())
         .spawn_and_forward_exit_code()
         .map_err(WttError::SpawnChild)?;
     let err = server.run(|| ClientWlDisplay {

--- a/apps/wl-cm-filter/src/cli.rs
+++ b/apps/wl-cm-filter/src/cli.rs
@@ -2,7 +2,7 @@ use {
     crate::{CmError, cm},
     clap::{CommandFactory, Parser, ValueHint},
     clap_complete::Shell,
-    std::io::stdout,
+    std::{io::stdout, os::fd::OwnedFd},
 };
 
 /// This application can be used to limit capabilities reported by wp-color-management-v1
@@ -55,7 +55,7 @@ pub struct WlCmFilter {
     pub program: Option<Vec<String>>,
 }
 
-pub fn main() -> Result<(), CmError> {
+pub fn main(wayland_socket: Option<OwnedFd>) -> Result<(), CmError> {
     let args = WlCmFilter::parse();
     if let Some(shell) = args.generate_completion {
         let stdout = stdout();
@@ -68,5 +68,5 @@ pub fn main() -> Result<(), CmError> {
         );
         return Ok(());
     }
-    cm::main(&args)
+    cm::main(&args, wayland_socket)
 }

--- a/apps/wl-cm-filter/src/cm.rs
+++ b/apps/wl-cm-filter/src/cm.rs
@@ -1,7 +1,7 @@
 use {
     crate::{CmError, cli::WlCmFilter},
     phf::phf_map,
-    std::{collections::HashSet, process::Command, rc::Rc, sync::Arc},
+    std::{collections::HashSet, os::fd::OwnedFd, process::Command, rc::Rc, sync::Arc},
     wl_proxy::{
         baseline::Baseline,
         object::{ConcreteObject, Object, ObjectCoreApi, ObjectRcUtils},
@@ -20,12 +20,13 @@ use {
     },
 };
 
-pub fn main(args: &WlCmFilter) -> Result<(), CmError> {
+pub fn main(args: &WlCmFilter, wayland_socket: Option<OwnedFd>) -> Result<(), CmError> {
     let program = args.program.as_ref().unwrap();
-    let server = SimpleProxy::new(Baseline::V5).map_err(CmError::CreateServer)?;
+    let server = SimpleProxy::new(Baseline::V5, wayland_socket).map_err(CmError::CreateServer)?;
     Command::new(&program[0])
         .args(&program[1..])
-        .with_wayland_display(server.display())
+        .with_optional_wayland_display(server.display())
+        .with_optional_wayland_socket(server.socket())
         .spawn_and_forward_exit_code()
         .map_err(CmError::SpawnChild)?;
     let filters = create_filters(args);

--- a/apps/wl-cm-filter/src/main.rs
+++ b/apps/wl-cm-filter/src/main.rs
@@ -1,10 +1,20 @@
-use {error_reporter::Report, std::io, thiserror::Error, wl_proxy::simple::SimpleProxyError};
+use {
+    error_reporter::Report,
+    std::io,
+    thiserror::Error,
+    wl_proxy::{
+        simple::SimpleProxyError,
+        state::{StateError, get_wayland_socket},
+    },
+};
 
 mod cli;
 mod cm;
 
 #[derive(Debug, Error)]
 enum CmError {
+    #[error("could not extract WAYLAND_SOCKET")]
+    WaylandSocket(#[source] StateError),
     #[error("could not create a simple server")]
     CreateServer(#[source] SimpleProxyError),
     #[error("could not spawn child")]
@@ -14,5 +24,9 @@ enum CmError {
 }
 
 fn main() -> Result<(), Report<CmError>> {
-    cli::main().map_err(Report::new)
+    let wayland_socket = unsafe {
+        // SAFETY: only reader of WAYLAND_SOCKET, child processes all remove/replace it
+        get_wayland_socket().map_err(CmError::WaylandSocket)?
+    };
+    cli::main(wayland_socket).map_err(Report::new)
 }

--- a/apps/wl-format-filter/src/cli.rs
+++ b/apps/wl-format-filter/src/cli.rs
@@ -6,7 +6,7 @@ use {
     clap::{CommandFactory, Parser, ValueHint},
     clap_complete::Shell,
     phf::phf_map,
-    std::io::stdout,
+    std::{io::stdout, os::fd::OwnedFd},
     thiserror::Error,
 };
 
@@ -284,7 +284,7 @@ static WAYLAND_FORMATS: phf::Map<&'static str, u32> = phf_map! {
       "s416"                 => 0x36313453,
 };
 
-pub fn main() -> Result<(), HfError> {
+pub fn main(wayland_socket: Option<OwnedFd>) -> Result<(), HfError> {
     let args = WlFormatFilter::parse();
     if let Some(shell) = args.generate_completion {
         let stdout = stdout();
@@ -297,5 +297,5 @@ pub fn main() -> Result<(), HfError> {
         );
         return Ok(());
     }
-    hf::main(args.allow, args.deny, args.program.unwrap())
+    hf::main(args.allow, args.deny, wayland_socket, args.program.unwrap())
 }

--- a/apps/wl-format-filter/src/hf.rs
+++ b/apps/wl-format-filter/src/hf.rs
@@ -25,11 +25,17 @@ use {
     },
 };
 
-pub fn main(allow: Vec<Filter>, deny: Vec<Filter>, program: Vec<String>) -> Result<(), HfError> {
-    let server = SimpleProxy::new(Baseline::V5).map_err(HfError::CreateServer)?;
+pub fn main(
+    allow: Vec<Filter>,
+    deny: Vec<Filter>,
+    wayland_socket: Option<OwnedFd>,
+    program: Vec<String>,
+) -> Result<(), HfError> {
+    let server = SimpleProxy::new(Baseline::V5, wayland_socket).map_err(HfError::CreateServer)?;
     Command::new(&program[0])
         .args(&program[1..])
-        .with_wayland_display(server.display())
+        .with_optional_wayland_display(server.display())
+        .with_optional_wayland_socket(server.socket())
         .spawn_and_forward_exit_code()
         .map_err(HfError::SpawnChild)?;
     let dispositions = create_disposition_list(&allow, &deny);

--- a/apps/wl-format-filter/src/main.rs
+++ b/apps/wl-format-filter/src/main.rs
@@ -1,12 +1,22 @@
 #![expect(clippy::from_str_radix_10)]
 
-use {error_reporter::Report, std::io, thiserror::Error, wl_proxy::simple::SimpleProxyError};
+use {
+    error_reporter::Report,
+    std::io,
+    thiserror::Error,
+    wl_proxy::{
+        simple::SimpleProxyError,
+        state::{StateError, get_wayland_socket},
+    },
+};
 
 mod cli;
 mod hf;
 
 #[derive(Debug, Error)]
 enum HfError {
+    #[error("could not extract WAYLAND_SOCKET")]
+    WaylandSocket(#[source] StateError),
     #[error("could not create a simple server")]
     CreateServer(#[source] SimpleProxyError),
     #[error("could not spawn child")]
@@ -16,5 +26,9 @@ enum HfError {
 }
 
 fn main() -> Result<(), Report<HfError>> {
-    cli::main().map_err(Report::new)
+    let wayland_socket = unsafe {
+        // SAFETY: only reader of WAYLAND_SOCKET, child processes all remove/replace it
+        get_wayland_socket().map_err(HfError::WaylandSocket)?
+    };
+    cli::main(wayland_socket).map_err(Report::new)
 }

--- a/apps/wl-paper/src/cli.rs
+++ b/apps/wl-paper/src/cli.rs
@@ -5,7 +5,7 @@ use {
     },
     clap::{CommandFactory, Parser, ValueEnum, ValueHint},
     clap_complete::Shell,
-    std::io::stdout,
+    std::{io::stdout, os::fd::OwnedFd},
     wl_proxy::protocols::wlr_layer_shell_unstable_v1::{
         zwlr_layer_shell_v1::ZwlrLayerShellV1Layer,
         zwlr_layer_surface_v1::ZwlrLayerSurfaceV1KeyboardInteractivity,
@@ -64,7 +64,7 @@ pub enum Layer {
     Overlay,
 }
 
-pub fn main() -> Result<(), PaperError> {
+pub fn main(wayland_socket: Option<OwnedFd>) -> Result<(), PaperError> {
     let args = WlPaper::parse();
     if let Some(shell) = args.generate_completion {
         let stdout = stdout();
@@ -90,5 +90,5 @@ pub fn main() -> Result<(), PaperError> {
         margin_left: args.margin_left,
         namespace: args.namespace,
     };
-    paper::main(config, &args.program.unwrap())
+    paper::main(config, wayland_socket, &args.program.unwrap())
 }

--- a/apps/wl-paper/src/main.rs
+++ b/apps/wl-paper/src/main.rs
@@ -2,12 +2,20 @@ mod cli;
 mod paper;
 
 use {
-    error_reporter::Report, log::LevelFilter, std::io, thiserror::Error,
-    wl_proxy::simple::SimpleProxyError,
+    error_reporter::Report,
+    log::LevelFilter,
+    std::io,
+    thiserror::Error,
+    wl_proxy::{
+        simple::SimpleProxyError,
+        state::{StateError, get_wayland_socket},
+    },
 };
 
 #[derive(Debug, Error)]
 enum PaperError {
+    #[error("could not extract WAYLAND_SOCKET")]
+    WaylandSocket(#[source] StateError),
     #[error("could not create a simple server")]
     CreateServer(#[source] SimpleProxyError),
     #[error("could not spawn child")]
@@ -17,9 +25,14 @@ enum PaperError {
 }
 
 fn main() -> Result<(), Report<PaperError>> {
+    let wayland_socket = unsafe {
+        // SAFETY: only reader of WAYLAND_SOCKET, child processes all remove/replace it
+        get_wayland_socket().map_err(PaperError::WaylandSocket)?
+    };
+
     env_logger::builder()
         .filter_level(LevelFilter::Info)
         .parse_default_env()
         .init();
-    cli::main().map_err(Report::new)
+    cli::main(wayland_socket).map_err(Report::new)
 }

--- a/apps/wl-paper/src/paper.rs
+++ b/apps/wl-paper/src/paper.rs
@@ -1,7 +1,7 @@
 use {
     crate::PaperError,
     arrayvec::ArrayVec,
-    std::{mem, process::Command, rc::Rc, sync::Arc},
+    std::{mem, os::fd::OwnedFd, process::Command, rc::Rc, sync::Arc},
     wl_proxy::{
         baseline::Baseline,
         global_mapper::GlobalMapper,
@@ -52,12 +52,18 @@ use {
     },
 };
 
-pub fn main(config: Config, program: &[String]) -> Result<(), PaperError> {
+pub fn main(
+    config: Config,
+    wayland_socket: Option<OwnedFd>,
+    program: &[String],
+) -> Result<(), PaperError> {
     let config = Arc::new(config);
-    let server = SimpleProxy::new(Baseline::V5).map_err(PaperError::CreateServer)?;
+    let server =
+        SimpleProxy::new(Baseline::V5, wayland_socket).map_err(PaperError::CreateServer)?;
     Command::new(&program[0])
         .args(&program[1..])
-        .with_wayland_display(server.display())
+        .with_optional_wayland_display(server.display())
+        .with_optional_wayland_socket(server.socket())
         .spawn_and_forward_exit_code()
         .map_err(PaperError::SpawnChild)?;
     let err = server.run(|| ClientWlDisplay {

--- a/apps/wl-veil/src/cli.rs
+++ b/apps/wl-veil/src/cli.rs
@@ -2,7 +2,7 @@ use {
     crate::{VeilError, veil},
     clap::{CommandFactory, Parser, ValueHint},
     clap_complete::Shell,
-    std::{collections::HashMap, io::stdout, num::ParseIntError, str::FromStr},
+    std::{collections::HashMap, io::stdout, num::ParseIntError, os::fd::OwnedFd, str::FromStr},
     thiserror::Error,
 };
 
@@ -67,7 +67,7 @@ fn parse_filter(s: &str) -> Result<(String, Option<u32>), ParseFilterError> {
     }
 }
 
-pub fn main() -> Result<(), VeilError> {
+pub fn main(wayland_socket: Option<OwnedFd>) -> Result<(), VeilError> {
     let args = WlVeil::parse();
     if let Some(shell) = args.generate_completion {
         let stdout = stdout();
@@ -79,5 +79,5 @@ pub fn main() -> Result<(), VeilError> {
     for f in args.filter {
         filter.extend(f);
     }
-    veil::main(args.invert, filter, args.program.unwrap())
+    veil::main(args.invert, filter, wayland_socket, args.program.unwrap())
 }

--- a/apps/wl-veil/src/main.rs
+++ b/apps/wl-veil/src/main.rs
@@ -1,6 +1,12 @@
 use {
-    error_reporter::Report, log::LevelFilter, std::io, thiserror::Error,
-    wl_proxy::simple::SimpleProxyError,
+    error_reporter::Report,
+    log::LevelFilter,
+    std::io,
+    thiserror::Error,
+    wl_proxy::{
+        simple::SimpleProxyError,
+        state::{StateError, get_wayland_socket},
+    },
 };
 
 mod cli;
@@ -8,6 +14,8 @@ mod veil;
 
 #[derive(Debug, Error)]
 enum VeilError {
+    #[error("could not extract WAYLAND_SOCKET")]
+    WaylandSocket(#[source] StateError),
     #[error("could not create a simple server")]
     CreateServer(#[source] SimpleProxyError),
     #[error("could not spawn child")]
@@ -17,9 +25,14 @@ enum VeilError {
 }
 
 fn main() -> Result<(), Report<VeilError>> {
+    let wayland_socket = unsafe {
+        // SAFETY: only reader of WAYLAND_SOCKET, child processes all remove/replace it
+        get_wayland_socket().map_err(VeilError::WaylandSocket)?
+    };
+
     env_logger::builder()
         .filter_level(LevelFilter::Info)
         .parse_default_env()
         .init();
-    cli::main().map_err(Report::new)
+    cli::main(wayland_socket).map_err(Report::new)
 }

--- a/apps/wl-veil/src/veil.rs
+++ b/apps/wl-veil/src/veil.rs
@@ -3,6 +3,7 @@ use {
     linearize::StaticMap,
     std::{
         collections::{HashMap, HashSet},
+        os::fd::OwnedFd,
         process::Command,
         rc::Rc,
         sync::Arc,
@@ -23,12 +24,15 @@ use {
 pub fn main(
     invert: bool,
     filter: HashMap<String, Option<u32>>,
+    wayland_socket: Option<OwnedFd>,
     program: Vec<String>,
 ) -> Result<(), VeilError> {
-    let server = SimpleProxy::new(Baseline::ALL_OF_THEM).map_err(VeilError::CreateServer)?;
+    let server =
+        SimpleProxy::new(Baseline::ALL_OF_THEM, wayland_socket).map_err(VeilError::CreateServer)?;
     Command::new(&program[0])
         .args(&program[1..])
-        .with_wayland_display(server.display())
+        .with_optional_wayland_display(server.display())
+        .with_optional_wayland_socket(server.socket())
         .spawn_and_forward_exit_code()
         .map_err(VeilError::SpawnChild)?;
     let filter = create_filter(invert, filter);

--- a/wl-proxy/src/lib.rs
+++ b/wl-proxy/src/lib.rs
@@ -23,6 +23,7 @@
 //! use wl_proxy::protocols::wayland::wl_region::WlRegionHandler;
 //! use wl_proxy::protocols::wayland::wl_registry::{WlRegistry, WlRegistryHandler};
 //! use wl_proxy::simple::{SimpleProxy, SimpleCommandExt};
+//! use wl_proxy::state::get_wayland_socket;
 //!
 //! // SimpleProxy is a helper type that creates one proxy per client and runs the proxy
 //! // in a thread.
@@ -30,11 +31,17 @@
 //! // semver-compatible updates of this crate to add new protocols and protocol versions
 //! // without causing protocol errors in existing proxies. Since this proxy is very
 //! // simple, we just expose all protocols supported by the crate.
-//! let proxy = SimpleProxy::new(Baseline::ALL_OF_THEM).unwrap();
+//! let wayland_socket = unsafe {
+//!     // SAFETY: called at most once
+//!     get_wayland_socket().unwrap()
+//! };
+//! let proxy = SimpleProxy::new(Baseline::ALL_OF_THEM, wayland_socket).unwrap();
 //! // This starts mpv and spawns a thread that waits for mpv to exit. When mpv exits,
 //! // the thread also calls exit to forward the exit code.
+//!
 //! Command::new("mpv")
-//!     .with_wayland_display(proxy.display())
+//!     .with_optional_wayland_display(proxy.display())
+//!     .with_optional_wayland_socket(proxy.socket())
 //!     .spawn_and_forward_exit_code()
 //!     .unwrap();
 //! // The closure is invoked once for each client that connects and must return a

--- a/wl-proxy/src/simple.rs
+++ b/wl-proxy/src/simple.rs
@@ -6,23 +6,36 @@ use {
         baseline::Baseline,
         client::ClientHandler,
         protocols::wayland::wl_display::WlDisplayHandler,
-        state::{Destructor, State},
-        utils::env::WAYLAND_DISPLAY,
+        state::{Destructor, RemoteDestructor, State, StateError},
+        utils::env::{WAYLAND_DISPLAY, WAYLAND_SOCKET},
     },
     error_reporter::Report,
     parking_lot::Mutex,
     run_on_drop::on_drop,
     std::{
         io,
-        os::unix::prelude::ExitStatusExt,
+        os::{
+            fd::{AsRawFd, OwnedFd},
+            unix::prelude::ExitStatusExt,
+        },
         process::{Command, exit},
         rc::Rc,
         sync::atomic::{AtomicUsize, Ordering::Relaxed},
         thread,
+        time::Duration,
     },
     thiserror::Error,
-    uapi::raise,
+    uapi::{c, raise},
 };
+
+enum ProxyMode {
+    WaylandDisplay(Rc<Acceptor>),
+    WaylandSocket {
+        compositor_connection: OwnedFd,
+        client_connection: OwnedFd,
+        client_opposite: OwnedFd,
+    },
+}
 
 /// A simple proxy server that spawns a thread for each client.
 ///
@@ -30,7 +43,7 @@ use {
 /// each client that connects to the acceptor.
 pub struct SimpleProxy {
     baseline: Baseline,
-    acceptor: Rc<Acceptor>,
+    mode: ProxyMode,
 }
 
 /// An error returned by a [`SimpleProxy`].
@@ -40,6 +53,8 @@ pub struct SimpleProxyError(#[from] SimpleProxyErrorKind);
 
 #[derive(Debug, Error)]
 enum SimpleProxyErrorKind {
+    #[error("could not create a socketpair")]
+    CreateSocketPair(#[source] io::Error),
     #[error("could not create an acceptor")]
     CreateAcceptor(#[source] AcceptorError),
     #[error("could not accept a connection")]
@@ -48,21 +63,108 @@ enum SimpleProxyErrorKind {
     SpawnThread(#[source] io::Error),
 }
 
+fn run_client_thread<H>(
+    id: usize,
+    state: Result<Rc<State>, StateError>,
+    client_socket: OwnedFd,
+    display_handler: impl Fn() -> H + Sync,
+    destructors: &Mutex<Option<Vec<RemoteDestructor>>>,
+) where
+    H: WlDisplayHandler,
+{
+    let state = match state {
+        Ok(s) => s,
+        Err(e) => {
+            log::error!("Could not create a new state: {}", Report::new(e));
+            return;
+        }
+    };
+    match state.create_remote_destructor() {
+        Ok(d) => match &mut *destructors.lock() {
+            Some(des) => des.push(d),
+            _ => return,
+        },
+        Err(e) => {
+            log::error!("Could not create a remote destructor: {}", Report::new(e),);
+            return;
+        }
+    }
+    let client = match state.add_client(&Rc::new(client_socket)) {
+        Ok(c) => c,
+        Err(e) => {
+            log::error!("Could not add client to state: {}", Report::new(e));
+            return;
+        }
+    };
+    client.set_handler(ClientHandlerImpl {
+        id,
+        _destructor: state.create_destructor(),
+    });
+    let handler = display_handler();
+    client.display().set_handler(handler);
+    while state.is_not_destroyed() {
+        if let Err(e) = state.dispatch_blocking() {
+            log::error!("Could not dispatch state: {}", Report::new(e));
+        }
+    }
+}
+
 impl SimpleProxy {
     /// Creates a new [`SimpleProxy`].
-    pub fn new(baseline: Baseline) -> Result<SimpleProxy, SimpleProxyError> {
+    pub fn new(
+        baseline: Baseline,
+        wayland_socket: Option<OwnedFd>,
+    ) -> Result<SimpleProxy, SimpleProxyError> {
         Ok(Self {
             baseline,
-            acceptor: Acceptor::new(1000, false).map_err(SimpleProxyErrorKind::CreateAcceptor)?,
+            mode: if let Some(compositor_connection) = wayland_socket {
+                let (client_connection, client_opposite) = uapi::socketpair(
+                    c::AF_UNIX,
+                    c::SOCK_STREAM | c::SOCK_NONBLOCK | c::SOCK_CLOEXEC,
+                    0,
+                )
+                .map_err(|e| SimpleProxyErrorKind::CreateSocketPair(e.into()))?;
+
+                uapi::fcntl_setfd(client_opposite.as_raw_fd(), 0)
+                    .map_err(|e| SimpleProxyErrorKind::CreateSocketPair(e.into()))?;
+
+                ProxyMode::WaylandSocket {
+                    compositor_connection,
+                    client_connection: client_connection.into(),
+                    client_opposite: client_opposite.into(),
+                }
+            } else {
+                ProxyMode::WaylandDisplay(
+                    Acceptor::new(1000, false).map_err(SimpleProxyErrorKind::CreateAcceptor)?,
+                )
+            },
         })
     }
 
-    /// Returns the name of the display used by this proxy.
+    /// Returns the name of the display used by this proxy, if one is used and WAYLAND_SOCKET
+    /// is not provided.
     ///
     /// The `WAYLAND_DISPLAY` environment variable should be set to this value for clients
     /// that should connect to this proxy. See [`SimpleCommandExt::with_wayland_display`].
-    pub fn display(&self) -> &str {
-        self.acceptor.display()
+    pub fn display(&self) -> Option<&str> {
+        match &self.mode {
+            ProxyMode::WaylandDisplay(acceptor) => Some(acceptor.display()),
+            ProxyMode::WaylandSocket { .. } => None,
+        }
+    }
+
+    /// Returns the file descriptor id used by this proxy, if one is used and WAYLAND_SOCKET
+    /// is not provided.
+    ///
+    /// The `WAYLAND_SOCKET` environment variable should be set to this value the client
+    /// that should connect to this proxy. See [`SimpleCommandExt::with_wayland_socket`].
+    pub fn socket(&self) -> Option<i32> {
+        match &self.mode {
+            ProxyMode::WaylandDisplay(_) => None,
+            ProxyMode::WaylandSocket {
+                client_opposite, ..
+            } => Some(client_opposite.as_raw_fd()),
+        }
     }
 
     /// Runs the proxy indefinitely.
@@ -76,65 +178,49 @@ impl SimpleProxy {
         let display_handler = &display_handler;
         let destructors = Mutex::new(Some(vec![]));
         let destructors = &destructors;
-        let err = thread::scope(|s| {
-            let _stop_all_proxies = on_drop(|| *destructors.lock() = None);
-            loop {
-                let socket = match self.acceptor.accept() {
-                    Ok(s) => s.expect("blocking acceptor returned None"),
-                    Err(e) => return SimpleProxyErrorKind::AcceptConnection(e),
-                };
+        match self.mode {
+            ProxyMode::WaylandDisplay(acceptor) => SimpleProxyError(thread::scope(|s| {
+                let _stop_all_proxies = on_drop(|| *destructors.lock() = None);
+                loop {
+                    let socket = match acceptor.accept() {
+                        Ok(s) => s.expect("blocking acceptor returned None"),
+                        Err(e) => return SimpleProxyErrorKind::AcceptConnection(e),
+                    };
+                    let id = ID.fetch_add(1, Relaxed);
+                    let name = format!("socket-{id}");
+                    log::debug!("Client {id} connected");
+                    let res =
+                        thread::Builder::new()
+                            .name(name.clone())
+                            .spawn_scoped(s, move || {
+                                let state =
+                                    State::builder(self.baseline).with_log_prefix(&name).build();
+                                run_client_thread(id, state, socket, display_handler, destructors);
+                            });
+                    if let Err(e) = res {
+                        return SimpleProxyErrorKind::SpawnThread(e);
+                    }
+                }
+            })),
+            ProxyMode::WaylandSocket {
+                compositor_connection,
+                client_connection,
+                client_opposite,
+            } => {
+                drop(client_opposite);
+
+                let state = State::builder(self.baseline)
+                    .with_log_prefix("socket")
+                    .with_server_fd(&Rc::new(compositor_connection))
+                    .build();
                 let id = ID.fetch_add(1, Relaxed);
-                let name = format!("socket-{id}");
-                log::debug!("Client {id} connected");
-                let res = thread::Builder::new()
-                    .name(name.clone())
-                    .spawn_scoped(s, move || {
-                        let state = State::builder(self.baseline).with_log_prefix(&name).build();
-                        let state = match state {
-                            Ok(s) => s,
-                            Err(e) => {
-                                log::error!("Could not create a new state: {}", Report::new(e));
-                                return;
-                            }
-                        };
-                        match state.create_remote_destructor() {
-                            Ok(d) => match &mut *destructors.lock() {
-                                Some(des) => des.push(d),
-                                _ => return,
-                            },
-                            Err(e) => {
-                                log::error!(
-                                    "Could not create a remote destructor: {}",
-                                    Report::new(e),
-                                );
-                                return;
-                            }
-                        }
-                        let client = match state.add_client(&Rc::new(socket)) {
-                            Ok(c) => c,
-                            Err(e) => {
-                                log::error!("Could not add client to state: {}", Report::new(e));
-                                return;
-                            }
-                        };
-                        client.set_handler(ClientHandlerImpl {
-                            id,
-                            _destructor: state.create_destructor(),
-                        });
-                        let handler = display_handler();
-                        client.display().set_handler(handler);
-                        while state.is_not_destroyed() {
-                            if let Err(e) = state.dispatch_blocking() {
-                                log::error!("Could not dispatch state: {}", Report::new(e));
-                            }
-                        }
-                    });
-                if let Err(e) = res {
-                    return SimpleProxyErrorKind::SpawnThread(e);
+                run_client_thread(id, state, client_connection, display_handler, destructors);
+
+                loop {
+                    std::thread::sleep(Duration::MAX);
                 }
             }
-        });
-        SimpleProxyError(err)
+        }
     }
 }
 
@@ -151,8 +237,30 @@ impl ClientHandler for ClientHandlerImpl {
 
 /// Extensions for [`Command`].
 pub trait SimpleCommandExt {
+    /// Sets the `WAYLAND_DISPLAY` environment variable if `display` is Some.
+    fn with_optional_wayland_display(&mut self, display: Option<&str>) -> &mut Command {
+        if let Some(disp) = display {
+            self.with_wayland_display(disp)
+        } else {
+            self.without_wayland_display()
+        }
+    }
+    /// Sets the `WAYLAND_DISPLAY` environment variable if `socket` is Some.
+    fn with_optional_wayland_socket(&mut self, socket: Option<i32>) -> &mut Command {
+        if let Some(sock) = socket {
+            self.with_wayland_socket(sock)
+        } else {
+            self.without_wayland_socket()
+        }
+    }
     /// Sets the `WAYLAND_DISPLAY` environment variable.
     fn with_wayland_display(&mut self, display: &str) -> &mut Command;
+    /// Sets the `WAYLAND_SOCKET` environment variable.
+    fn with_wayland_socket(&mut self, socket: i32) -> &mut Command;
+    /// Clears any `WAYLAND_DISPLAY` environment variable.
+    fn without_wayland_display(&mut self) -> &mut Command;
+    /// Clears any `WAYLAND_SOCKET` environment variable.
+    fn without_wayland_socket(&mut self) -> &mut Command;
     /// Spawns the application, waits for it to exit, and then calls [`exit`] with the
     /// same exit code.
     fn spawn_and_forward_exit_code(&mut self) -> Result<(), io::Error>;
@@ -161,6 +269,18 @@ pub trait SimpleCommandExt {
 impl SimpleCommandExt for Command {
     fn with_wayland_display(&mut self, display: &str) -> &mut Command {
         self.env(WAYLAND_DISPLAY, display)
+    }
+
+    fn with_wayland_socket(&mut self, socket: i32) -> &mut Command {
+        self.env(WAYLAND_SOCKET, socket.to_string())
+    }
+
+    fn without_wayland_display(&mut self) -> &mut Command {
+        self.env_remove(WAYLAND_DISPLAY)
+    }
+
+    fn without_wayland_socket(&mut self) -> &mut Command {
+        self.env_remove(WAYLAND_SOCKET)
     }
 
     fn spawn_and_forward_exit_code(&mut self) -> Result<(), io::Error> {

--- a/wl-proxy/src/state.rs
+++ b/wl-proxy/src/state.rs
@@ -22,9 +22,11 @@ use {
     std::{
         cell::{Cell, RefCell},
         collections::HashMap,
+        env::var_os,
         io::{self, pipe},
-        os::fd::{AsFd, AsRawFd, OwnedFd},
+        os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd},
         rc::{Rc, Weak},
+        str::FromStr,
         sync::{
             Arc,
             atomic::{AtomicBool, Ordering::Acquire},
@@ -93,6 +95,35 @@ enum StateErrorKind {
     PollError(PollError),
     #[error("Could not create an eventfd")]
     CreateEventfd(#[source] io::Error),
+}
+
+///
+/// Get the current Wayland socket.
+///
+/// After this is called, the environment variable WAYLAND_SOCKET should be
+/// replaced or removed for all child processes.
+///
+/// # Safety
+///
+/// Specifically, I/O-safety; this should be invoked at most once by the program;
+/// no other similar function reading WAYLAND_SOCKET should be used; and if this
+/// returns Some, then returned file descriptor must be kept CLOEXEC.
+///
+pub unsafe fn get_wayland_socket() -> Result<Option<OwnedFd>, StateError> {
+    let Some(wayland_socket) = var_os(WAYLAND_SOCKET) else {
+        return Ok(None);
+    };
+    let fd = str::from_utf8(wayland_socket.as_encoded_bytes())
+        .ok()
+        .and_then(|s| i32::from_str(s).ok())
+        .ok_or(StateErrorKind::WaylandSocketNotNumber)?;
+    let flags = uapi::fcntl_getfd(fd).map_err(|e| StateErrorKind::WaylandSocketGetFd(e.into()))?;
+    uapi::fcntl_setfd(fd, flags | c::FD_CLOEXEC)
+        .map_err(|e| StateErrorKind::WaylandSocketSetFd(e.into()))?;
+    Ok(Some(unsafe {
+        // SAFETY: This requires the caller to invoke this once with valid WAYLAND_SOCKET
+        OwnedFd::from_raw_fd(fd)
+    }))
 }
 
 /// The proxy state.

--- a/wl-proxy/src/state/builder.rs
+++ b/wl-proxy/src/state/builder.rs
@@ -6,19 +6,15 @@ use {
         poll::{self, Poller},
         protocols::wayland::wl_display::WlDisplay,
         state::{EndpointWithClient, Pollable, State, StateError, StateErrorKind},
-        utils::env::{WAYLAND_DISPLAY, WAYLAND_SOCKET, WL_PROXY_DEBUG, XDG_RUNTIME_DIR},
+        utils::env::{WAYLAND_DISPLAY, WL_PROXY_DEBUG, XDG_RUNTIME_DIR},
     },
     linearize::Linearize,
     std::{
         cell::{Cell, RefCell},
         collections::HashMap,
-        env::{remove_var, var, var_os},
-        os::{
-            fd::{AsFd, FromRawFd, OwnedFd},
-            unix::ffi::OsStrExt,
-        },
+        env::var,
+        os::fd::{AsFd, OwnedFd},
         rc::Rc,
-        str::FromStr,
     },
     uapi::c::{self, sockaddr_un},
 };
@@ -59,10 +55,10 @@ impl StateBuilder {
     ///
     /// The server to connect to is chosen as follows:
     ///
-    /// - If [`Self::with_server_fd`] was used, that FD is used.
+    /// - If [`Self::with_server_fd`] was used, that FD is used. To support WAYLAND_SOCKET,
+    ///   callers must explicitly provide the server FD.
     /// - Otherwise, if [`Self::with_server_display_name`] was used, that display name is
     ///   used.
-    /// - Otherwise, if the `WAYLAND_SOCKET` environment variable is set, that FD is used.
     /// - Otherwise, the display name from the `WAYLAND_DISPLAY` environment variable is
     ///   used.
     pub fn build(self) -> Result<Rc<State>, StateError> {
@@ -73,24 +69,6 @@ impl StateBuilder {
                 Some(Server::Fd(fd)) => break 'fd Some(fd),
                 Some(Server::DisplayName(n)) => Some(n),
             };
-            if display_name.is_none()
-                && let Some(wayland_socket) = var_os(WAYLAND_SOCKET)
-            {
-                let fd = str::from_utf8(wayland_socket.as_bytes())
-                    .ok()
-                    .and_then(|s| i32::from_str(s).ok())
-                    .ok_or(StateErrorKind::WaylandSocketNotNumber)?;
-                let flags = uapi::fcntl_getfd(fd)
-                    .map_err(|e| StateErrorKind::WaylandSocketGetFd(e.into()))?;
-                uapi::fcntl_setfd(fd, flags | c::FD_CLOEXEC)
-                    .map_err(|e| StateErrorKind::WaylandSocketSetFd(e.into()))?;
-                // SAFETY: This is unsound.
-                let fd = unsafe {
-                    remove_var(WAYLAND_SOCKET);
-                    Rc::new(OwnedFd::from_raw_fd(fd))
-                };
-                break 'fd Some(fd);
-            }
             let mut name = match display_name {
                 Some(n) => n,
                 _ => var(WAYLAND_DISPLAY)
@@ -232,6 +210,16 @@ impl StateBuilder {
     /// Sets the server file descriptor to connect to.
     pub fn with_server_fd(mut self, fd: &Rc<OwnedFd>) -> Self {
         self.server = Some(Server::Fd(fd.clone()));
+        self
+    }
+
+    /// Sets the server file descriptor to connect to.
+    pub fn with_server_opt_fd(mut self, fd: &Option<Rc<OwnedFd>>) -> Self {
+        if let Some(rfd) = fd {
+            self.server = Some(Server::Fd(rfd.clone()));
+        } else {
+            self.server = None;
+        }
         self
     }
 


### PR DESCRIPTION
This refactors the SimpleProxy so that it no longer tries to capture the WAYLAND_SOCKET file descriptor from the environment when present, because this is I/O-safety unsound if the code to capture the socket fd is run in multiple threads at the same time. Now this is the program's responsibility, because only main() can reliably ensure that this is done at most once, and before anything else. This makes all applications a bit more complicated.

(Note that the hypothetical alternative of a global mutex could only ensure that `wl-proxy` or any other library using that mutex captures WAYLAND_SOCKET once, but cannot control what other code might do with the file descriptor or environment variable value. For example, using `std::env::set_var` to set WAYLAND_SOCKET to an arbitrary value in a single threaded program is stated to be sound by the standard library docs, so safe code could have created an OwnedFd, and set WAYLAND_SOCKET to its as_raw_fd() value, after which creating a new OwnedFd from WAYLAND_SOCKET would violate OwnedFd's exclusive ownership requirement.)

I've also updated the logic so that SimpleProxy only tries to make one connection out of the incoming WAYLAND_SOCKET and then only sets WAYLAND_SOCKET and not WAYLAND_DISPLAY, so that only a single client can connect.

I am by no means certain that this is the right approach; it _does_ appear a bit contorted. Among other details, I'm uncertain whether `get_wayland_socket()` should call `std::env::remove_var`, which would constrain how it is called a bit, but could make interop with other Wayland client libraries a bit easier. 

Please let me know if you'd like me to make major changes, split off any part of this, etc.